### PR TITLE
Use VAOs in cube renderer

### DIFF
--- a/src/api/XRSessionWithLayer.ts
+++ b/src/api/XRSessionWithLayer.ts
@@ -93,6 +93,7 @@ export class XRSessionWithLayer {
 					}
 
 					gl.bindFramebuffer(gl.FRAMEBUFFER, this.tempFramebuffer)
+					gl.clearColor(0, 0, 0, 0);
 					for (let layer of this.layers) {
 						// TODO: spec says all of them should be cleared, but clearing quad layers causes the layer
 						// to disappear...

--- a/src/gl/base-renderer.ts
+++ b/src/gl/base-renderer.ts
@@ -276,6 +276,7 @@ export class CompositionLayerRenderer {
 				} else {
 					this._renderInternal(session, frame, view, layer)
 				}
+				gl.bindTexture(gl.TEXTURE_2D_ARRAY, null)
 			} else {
 				if (this.layer.isMediaLayer()) {
 					// we have to bind the media to gl instead!
@@ -319,6 +320,7 @@ export class CompositionLayerRenderer {
 				} else {
 					this._renderInternal(session, frame, view)
 				}
+				gl.bindTexture(gl.TEXTURE_2D, null)
 			}
 		}
 	}
@@ -401,6 +403,7 @@ export class CompositionLayerRenderer {
 			stride,
 			offset
 		)
+		gl.bindBuffer(gl.ARRAY_BUFFER, null)
 	}
 
 	// INITIALIZATION
@@ -517,6 +520,7 @@ export class CompositionLayerRenderer {
 		)
 
 		this.vaoGl.bindVertexArray(null)
+		gl.bindBuffer(gl.ARRAY_BUFFER, null)
 	}
 
 	// RENDERING

--- a/src/gl/projection-renderer.ts
+++ b/src/gl/projection-renderer.ts
@@ -125,8 +125,9 @@ class ProjectionRenderer implements LayerRenderer {
 			gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
 			gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
 			gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
-		} else if (gl instanceof WebGL2RenderingContext) {
-			gl.bindTexture(gl.TEXTURE_2D_ARRAY, this.layer.colorTextures[0])
+		} else {
+			throw new Error(`Created a texture projection renderer instead of a texture-array projection renderer for a texture-array layer. 
+This is probably an error with the polyfill itself; please file an issue on Github if you run into this.`)
 		}
 
 		for (let view of session.internalViews) {
@@ -139,6 +140,7 @@ class ProjectionRenderer implements LayerRenderer {
 				this._renderInternal()
 			}
 		}
+		gl.bindTexture(gl.TEXTURE_2D, null)
 	}
 
 	_renderInternal() {
@@ -231,6 +233,7 @@ class ProjectionRenderer implements LayerRenderer {
 		)
 
 		this.vaoGl.bindVertexArray(null)
+		gl.bindBuffer(gl.ARRAY_BUFFER, null)
 	}
 
 	_setStereoTextureBuffer(index: number) {
@@ -255,6 +258,7 @@ class ProjectionRenderer implements LayerRenderer {
 			stride,
 			offset
 		)
+		gl.bindBuffer(gl.ARRAY_BUFFER, null)
 	}
 
 	_createTextureUVs() {
@@ -427,6 +431,7 @@ class ProjectionTextureArrayRenderer extends ProjectionRenderer implements Layer
 
 			this._renderInternal(index)
 		}
+		gl.bindTexture(gl.TEXTURE_2D_ARRAY, null)
 	}
 
 	_renderInternal(layer: number = 0) {


### PR DESCRIPTION
This is an attempt to fix #8 - the PR adds a series of lines to reset gl state and unbind various buffers, as well as updating the cube layer renderer to use VAOs instead of setting position buffers directly.