### PR TITLE
Restore texture state after rendering layers

### DIFF
--- a/src/api/XRCompositionLayerPolyfill.ts
+++ b/src/api/XRCompositionLayerPolyfill.ts
@@ -469,9 +469,10 @@ export default class XRCompositionLayerPolyfill implements XRCompositionLayer {
 			console.warn(
 				'texture-array layers are supported...questionably in the polyfill at the moment. Use at your own risk.'
 			)
-			// TODO: This is probably wrong. It renders without error, but
-			// it renders...questionably.
 			// create a 2d texture array
+			const existingTextureBinding = this.context.getParameter(
+				this.context.TEXTURE_BINDING_2D_ARRAY
+			)
 			this.context.bindTexture(this.context.TEXTURE_2D_ARRAY, texture)
 			if (
 				textureFormat === this.context.DEPTH_COMPONENT ||
@@ -500,8 +501,10 @@ export default class XRCompositionLayerPolyfill implements XRCompositionLayer {
 					null
 				)
 			}
+			this.context.bindTexture(this.context.TEXTURE_2D_ARRAY, existingTextureBinding)
 		} else {
 			// regular texture 2d
+			const existingTextureBinding = this.context.getParameter(this.context.TEXTURE_BINDING_2D)
 			this.context.bindTexture(this.context.TEXTURE_2D, texture)
 			this.context.texImage2D(
 				this.context.TEXTURE_2D,
@@ -514,8 +517,8 @@ export default class XRCompositionLayerPolyfill implements XRCompositionLayer {
 				texImageType,
 				null
 			)
+			this.context.bindTexture(this.context.TEXTURE_2D, existingTextureBinding)
 		}
-
 		return textureMeta
 	}
 

--- a/src/api/XRCubeLayer.ts
+++ b/src/api/XRCubeLayer.ts
@@ -135,6 +135,7 @@ export default class XRCubeLayer extends XRCompositionLayerPolyfill {
 			texture,
 		}
 
+		const existingTextureBinding = this.context.getParameter(this.context.TEXTURE_BINDING_CUBE_MAP)
 		this.context.bindTexture(this.context.TEXTURE_CUBE_MAP, texture)
 
 		// initialize size for all the sides of the cubemap
@@ -151,6 +152,7 @@ export default class XRCubeLayer extends XRCompositionLayerPolyfill {
 				null
 			)
 		}
+		this.context.bindTexture(this.context.TEXTURE_CUBE_MAP, existingTextureBinding)
 
 		return textureMeta
 	}
@@ -166,6 +168,7 @@ export default class XRCubeLayer extends XRCompositionLayerPolyfill {
 			texture,
 		}
 
+		const existingTextureBinding = this.context.getParameter(this.context.TEXTURE_BINDING_CUBE_MAP)
 		this.context.bindTexture(this.context.TEXTURE_CUBE_MAP, texture)
 
 		// DEPTH_COMPONENT is not a valid internalFormat in WebGL2.
@@ -191,6 +194,7 @@ export default class XRCubeLayer extends XRCompositionLayerPolyfill {
 				null
 			)
 		}
+		this.context.bindTexture(this.context.TEXTURE_CUBE_MAP, existingTextureBinding)
 
 		return textureMeta
 	}

--- a/src/api/XRSessionWithLayer.ts
+++ b/src/api/XRSessionWithLayer.ts
@@ -93,7 +93,7 @@ export class XRSessionWithLayer {
 					}
 
 					gl.bindFramebuffer(gl.FRAMEBUFFER, this.tempFramebuffer)
-					gl.clearColor(0, 0, 0, 0);
+					gl.clearColor(0, 0, 0, 0)
 					for (let layer of this.layers) {
 						// TODO: spec says all of them should be cleared, but clearing quad layers causes the layer
 						// to disappear...
@@ -254,7 +254,12 @@ export class XRSessionWithLayer {
 					}
 
 					// restore previous blendFunc
-					gl.blendFuncSeparate(prevBlendSrcRGB, prevBlendDestRGB, prevBlendSrcAlpha, prevBlendDestAlpha)
+					gl.blendFuncSeparate(
+						prevBlendSrcRGB,
+						prevBlendDestRGB,
+						prevBlendSrcAlpha,
+						prevBlendDestAlpha
+					)
 
 					// run task queue
 					while (this.taskQueue.length > 0) {

--- a/src/gl/base-renderer.ts
+++ b/src/gl/base-renderer.ts
@@ -211,6 +211,7 @@ export class CompositionLayerRenderer {
 				type: XRTextureType.texture,
 			}
 
+			const existingTextureBinding = gl.getParameter(gl.TEXTURE_BINDING_2D)
 			gl.bindTexture(gl.TEXTURE_2D, this.mediaTexture)
 			gl.texImage2D(
 				gl.TEXTURE_2D,
@@ -223,7 +224,7 @@ export class CompositionLayerRenderer {
 				gl.UNSIGNED_BYTE,
 				null
 			)
-			gl.bindTexture(gl.TEXTURE_2D, null)
+			gl.bindTexture(gl.TEXTURE_2D, existingTextureBinding)
 		}
 
 		// setup geometry and VAO
@@ -255,6 +256,8 @@ export class CompositionLayerRenderer {
 
 				// if we're using texture-array, there is always only a single entry in layer.colorTextures
 				// and instead we use the layers uniform to render out individual pieces.
+				const existingTextureBinding = gl.getParameter(gl.TEXTURE_BINDING_2D_ARRAY)
+
 				gl.bindTexture(gl.TEXTURE_2D_ARRAY, this.layer.colorTextures[0])
 				gl.texParameteri(gl.TEXTURE_2D_ARRAY, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
 				gl.texParameteri(gl.TEXTURE_2D_ARRAY, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
@@ -276,8 +279,10 @@ export class CompositionLayerRenderer {
 				} else {
 					this._renderInternal(session, frame, view, layer)
 				}
-				gl.bindTexture(gl.TEXTURE_2D_ARRAY, null)
+				gl.bindTexture(gl.TEXTURE_2D_ARRAY, existingTextureBinding)
 			} else {
+				const existingTextureBinding = gl.getParameter(gl.TEXTURE_BINDING_2D)
+
 				if (this.layer.isMediaLayer()) {
 					// we have to bind the media to gl instead!
 					gl.bindTexture(gl.TEXTURE_2D, this.mediaTexture)
@@ -320,7 +325,7 @@ export class CompositionLayerRenderer {
 				} else {
 					this._renderInternal(session, frame, view)
 				}
-				gl.bindTexture(gl.TEXTURE_2D, null)
+				gl.bindTexture(gl.TEXTURE_2D, existingTextureBinding)
 			}
 		}
 	}

--- a/src/gl/cube-renderer.ts
+++ b/src/gl/cube-renderer.ts
@@ -111,6 +111,7 @@ export class CubeRenderer implements LayerRenderer {
 			gl.viewport(viewport.x, viewport.y, viewport.width, viewport.height)
 
 			gl.activeTexture(gl.TEXTURE0)
+			const existingTextureBinding = gl.getParameter(gl.TEXTURE_BINDING_CUBE_MAP);
 			// STEREO CASE: 0 is left eye, 1 is right eye
 			if (this.layer.layout === XRLayerLayout.stereo) {
 				const index = view.eye === 'right' ? 1 : 0
@@ -123,7 +124,7 @@ export class CubeRenderer implements LayerRenderer {
 			gl.texParameteri(gl.TEXTURE_CUBE_MAP, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
 
 			this._renderInternal(this.layer.orientation, view)
-			gl.bindTexture(gl.TEXTURE_CUBE_MAP, null)
+			gl.bindTexture(gl.TEXTURE_CUBE_MAP, existingTextureBinding)
 		}
 	}
 

--- a/src/gl/projection-renderer.ts
+++ b/src/gl/projection-renderer.ts
@@ -117,6 +117,8 @@ class ProjectionRenderer implements LayerRenderer {
 		// get texture type of layer
 		const textureType = this.layer.getTextureType()
 
+		const existingTextureBinding = gl.getParameter(gl.TEXTURE_BINDING_2D)
+
 		if (textureType === XRTextureType.texture) {
 			gl.bindTexture(gl.TEXTURE_2D, this.layer.colorTextures[0])
 
@@ -140,7 +142,7 @@ This is probably an error with the polyfill itself; please file an issue on Gith
 				this._renderInternal()
 			}
 		}
-		gl.bindTexture(gl.TEXTURE_2D, null)
+		gl.bindTexture(gl.TEXTURE_2D, existingTextureBinding)
 	}
 
 	_renderInternal() {
@@ -420,6 +422,8 @@ class ProjectionTextureArrayRenderer extends ProjectionRenderer implements Layer
 		let baseLayer = session.getBaseLayer()
 
 		// get texture type of layer
+		const existingTextureBinding = gl.getParameter(gl.TEXTURE_BINDING_2D_ARRAY)
+
 		gl.bindTexture(gl.TEXTURE_2D_ARRAY, this.layer.colorTextures[0])
 		gl.texParameteri(gl.TEXTURE_2D_ARRAY, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
 		gl.texParameteri(gl.TEXTURE_2D_ARRAY, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
@@ -431,7 +435,7 @@ class ProjectionTextureArrayRenderer extends ProjectionRenderer implements Layer
 
 			this._renderInternal(index)
 		}
-		gl.bindTexture(gl.TEXTURE_2D_ARRAY, null)
+		gl.bindTexture(gl.TEXTURE_2D_ARRAY, existingTextureBinding)
 	}
 
 	_renderInternal(layer: number = 0) {


### PR DESCRIPTION
This should address #9, where textures were not being restored after the polyfill renders the layers. This ensures that any call to `bindTexture` immediately restores the previously bound texture once we're done using it.