### PR TITLE
Restore clear color and program state after polyfill draws layers

### DIFF
--- a/src/api/XRSessionWithLayer.ts
+++ b/src/api/XRSessionWithLayer.ts
@@ -93,6 +93,7 @@ export class XRSessionWithLayer {
 					}
 
 					gl.bindFramebuffer(gl.FRAMEBUFFER, this.tempFramebuffer)
+					const existingClearColor = gl.getParameter(gl.COLOR_CLEAR_VALUE)
 					gl.clearColor(0, 0, 0, 0)
 					for (let layer of this.layers) {
 						// TODO: spec says all of them should be cleared, but clearing quad layers causes the layer
@@ -140,6 +141,12 @@ export class XRSessionWithLayer {
 					// clear base framebuffer before rendering anything
 					gl.bindFramebuffer(gl.FRAMEBUFFER, this.getBaseLayer().framebuffer)
 					gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT)
+					gl.clearColor(
+						existingClearColor[0],
+						existingClearColor[1],
+						existingClearColor[2],
+						existingClearColor[3]
+					)
 				}
 
 				animationFrameCallback(time, frame)
@@ -157,6 +164,7 @@ export class XRSessionWithLayer {
 					// blend function to operate. And for alpha to multiply.
 					gl.enable(gl.BLEND)
 					gl.disable(gl.DEPTH_TEST)
+					gl.disable(gl.CULL_FACE)
 
 					let prevBlendSrcRGB = gl.getParameter(gl.BLEND_SRC_RGB)
 					let prevBlendSrcAlpha = gl.getParameter(gl.BLEND_SRC_ALPHA)

--- a/src/gl/base-renderer.ts
+++ b/src/gl/base-renderer.ts
@@ -540,6 +540,7 @@ export class CompositionLayerRenderer {
 		let gl = this.gl
 
 		// Tell it to use our program (pair of shaders)
+		const existingProgram = gl.getParameter(gl.CURRENT_PROGRAM)
 		gl.useProgram(this.program)
 		this.vaoGl.bindVertexArray(this.vao)
 
@@ -565,6 +566,7 @@ export class CompositionLayerRenderer {
 		gl.drawArrays(primitiveType, offset, count)
 
 		this.vaoGl.bindVertexArray(null)
+		gl.useProgram(existingProgram)
 	}
 
 	// this is used only for stereo-left-right and stereo-top-bottom layers, and is used to render
@@ -577,6 +579,7 @@ export class CompositionLayerRenderer {
 		this.vaoGl.bindVertexArray(this.vao)
 
 		// Tell it to use our program (pair of shaders)
+		const existingProgram = gl.getParameter(gl.CURRENT_PROGRAM)
 		gl.useProgram(this.program)
 
 		// set position array and texture array
@@ -607,6 +610,7 @@ export class CompositionLayerRenderer {
 		gl.drawArrays(primitiveType, offset, count)
 
 		this.vaoGl.bindVertexArray(null)
+		gl.useProgram(existingProgram)
 	}
 
 	_setTransformMatrix(session: XRSessionWithLayer, frame: XRFrame, view: XRView) {

--- a/src/gl/cube-renderer.ts
+++ b/src/gl/cube-renderer.ts
@@ -181,7 +181,8 @@ export class CubeRenderer implements LayerRenderer {
 	_poseOrientationMatrix: mat4
 	_renderInternal(orientation: DOMPointReadOnly, view: XRView) {
 		let gl = this.gl
-		// Tell it to use our program (pair of shaders)
+		
+		const existingProgram = gl.getParameter(gl.CURRENT_PROGRAM)
 		gl.useProgram(this.program)
 		this.vaoGl.bindVertexArray(this.vao)
 
@@ -222,6 +223,7 @@ export class CubeRenderer implements LayerRenderer {
 		var count = this.positionPoints.length / 3
 		gl.drawArrays(primitiveType, offset, count)
 		this.vaoGl.bindVertexArray(null)
+		gl.useProgram(existingProgram)
 	}
 
 	_recalculateVertices() {

--- a/src/gl/projection-renderer.ts
+++ b/src/gl/projection-renderer.ts
@@ -147,6 +147,7 @@ This is probably an error with the polyfill itself; please file an issue on Gith
 
 	_renderInternal() {
 		let gl = this.gl
+		const existingProgram = gl.getParameter(gl.CURRENT_PROGRAM)
 		gl.useProgram(this.program)
 		this.vaoGl.bindVertexArray(this.vao)
 
@@ -157,6 +158,7 @@ This is probably an error with the polyfill itself; please file an issue on Gith
 		gl.drawArrays(primitiveType, offset, count)
 
 		this.vaoGl.bindVertexArray(null)
+		gl.useProgram(existingProgram)
 	}
 
 	// this is used only for stereo-left-right and stereo-top-bottom layers, and is used to render
@@ -168,7 +170,7 @@ This is probably an error with the polyfill itself; please file an issue on Gith
 		let gl = this.gl
 		this.vaoGl.bindVertexArray(this.vao)
 
-		// Tell it to use our program (pair of shaders)
+		const existingProgram = gl.getParameter(gl.CURRENT_PROGRAM)
 		gl.useProgram(this.program)
 
 		// set position array and texture array
@@ -182,6 +184,7 @@ This is probably an error with the polyfill itself; please file an issue on Gith
 		gl.drawArrays(primitiveType, offset, count)
 
 		this.vaoGl.bindVertexArray(null)
+		gl.useProgram(existingProgram)
 	}
 
 	_createVAOs() {
@@ -440,6 +443,7 @@ class ProjectionTextureArrayRenderer extends ProjectionRenderer implements Layer
 
 	_renderInternal(layer: number = 0) {
 		let gl = this.gl
+		const existingProgram = gl.getParameter(gl.CURRENT_PROGRAM)
 		gl.useProgram(this.program)
 		gl.bindVertexArray(this.vao)
 
@@ -451,6 +455,7 @@ class ProjectionTextureArrayRenderer extends ProjectionRenderer implements Layer
 		var count = 6
 		gl.drawArrays(primitiveType, offset, count)
 		gl.bindVertexArray(null)
+		gl.useProgram(existingProgram)
 	}
 }
 


### PR DESCRIPTION
Fixes a few more visual issues with the polyfill, namely:
1. Restores the clearColor after clearing the layers to transparency, as per spec
2. Restores the GL program after rendering
3. Disables CULL_FACE while rendering layers to avoid having cube layers occasionally disappear.