### PR TITLE
Add handling for depth stencil formats.

### DIFF
--- a/src/api/XRCubeLayer.ts
+++ b/src/api/XRCubeLayer.ts
@@ -178,6 +178,9 @@ export default class XRCubeLayer extends XRCompositionLayerPolyfill {
 			if (internalFormat === this.context.DEPTH_COMPONENT) {
 				internalFormat = this.context.DEPTH_COMPONENT24
 			}
+			if (internalFormat === this.context.DEPTH_STENCIL) {
+				internalFormat = this.context.DEPTH24_STENCIL8
+			}
 		}
 
 		// initialize size for all the sides of the cubemap

--- a/src/gl/webgl-utils.ts
+++ b/src/gl/webgl-utils.ts
@@ -113,9 +113,9 @@ export const applyVAOExtension = (gl: XRWebGLRenderingContext): VAOFunctions => 
 	}
 
 	return {
-		bindVertexArray: ext.bindVertexArrayOES,
-		createVertexArray: ext.createVertexArrayOES,
-		deleteVertexArray: ext.deleteVertexArrayOES,
-		isVertexArray: ext.isVertexArrayOES,
+		bindVertexArray: ext.bindVertexArrayOES.bind(ext),
+		createVertexArray: ext.createVertexArrayOES.bind(ext),
+		deleteVertexArray: ext.deleteVertexArrayOES.bind(ext),
+		isVertexArray: ext.isVertexArrayOES.bind(ext),
 	}
 }


### PR DESCRIPTION
Addresses #10.

This adds checks for DEPTH_STENCIL and DEPTH24_STENCIL8 formats (for WebGL2 contexts) when creating depth textures for all layer types.

The second commit fixes an issue where the polyfill fails to create VAOs in WebGL1 contexts.