### PR TITLE
fix: map RGBA8 internal format to RGBA texture format

### DIFF
--- a/src/api/XRCompositionLayerPolyfill.ts
+++ b/src/api/XRCompositionLayerPolyfill.ts
@@ -461,6 +461,11 @@ export default class XRCompositionLayerPolyfill implements XRCompositionLayer {
 			if (internalFormat === this.context.SRGB8_ALPHA8) {
 				textureFormat = this.context.RGBA
 			}
+			// ThreeJS still use RGBA8 as projection layer source
+			// https://github.com/mrdoob/three.js/blob/master/src/renderers/webxr/WebXRManager.js#L307
+			if (internalFormat === this.context.RGBA8) {
+				textureFormat = this.context.RGBA;
+			}
 		}
 
 		// calculate the texture's image type

--- a/src/api/XRCompositionLayerPolyfill.ts
+++ b/src/api/XRCompositionLayerPolyfill.ts
@@ -449,6 +449,12 @@ export default class XRCompositionLayerPolyfill implements XRCompositionLayer {
 		if (this.context instanceof WebGL2RenderingContext) {
 			if (internalFormat === this.context.DEPTH_COMPONENT) {
 				internalFormat = this.context.DEPTH_COMPONENT24
+			} else if (internalFormat === this.context.DEPTH_COMPONENT24) {
+				textureFormat = this.context.DEPTH_COMPONENT;
+			} else if (internalFormat === this.context.DEPTH24_STENCIL8) {
+				// ??
+				// this is possible?
+				textureFormat = this.context.DEPTH_STENCIL;
 			}
 			if (internalFormat === this.context.DEPTH_STENCIL) {
 				internalFormat = this.context.DEPTH24_STENCIL8
@@ -472,17 +478,17 @@ export default class XRCompositionLayerPolyfill implements XRCompositionLayer {
 		// For depth components, UNSIGNED_BYTE is not a valid image type
 		// we need to use UNSIGNED_INT instead.
 		let texImageType = this.context.UNSIGNED_BYTE
-		if (textureFormat === this.context.DEPTH_COMPONENT) {
+		if (internalFormat === this.context.DEPTH_COMPONENT) {
 			texImageType = this.context.UNSIGNED_INT
 		}
 
 		if (this.context instanceof WebGL2RenderingContext) {
-			if (textureFormat === this.context.DEPTH_COMPONENT24) {
+			if (internalFormat === this.context.DEPTH_COMPONENT24) {
 				texImageType = this.context.UNSIGNED_INT
 			}
 			if (
-				textureFormat === this.context.DEPTH24_STENCIL8 ||
-				textureFormat === this.context.DEPTH_STENCIL
+				internalFormat === this.context.DEPTH24_STENCIL8 ||
+				internalFormat === this.context.DEPTH_STENCIL
 			) {
 				texImageType = this.context.UNSIGNED_INT_24_8
 			}

--- a/src/api/XRCompositionLayerPolyfill.ts
+++ b/src/api/XRCompositionLayerPolyfill.ts
@@ -452,11 +452,8 @@ export default class XRCompositionLayerPolyfill implements XRCompositionLayer {
 			} else if (internalFormat === this.context.DEPTH_COMPONENT24) {
 				textureFormat = this.context.DEPTH_COMPONENT;
 			} else if (internalFormat === this.context.DEPTH24_STENCIL8) {
-				// ??
-				// this is possible?
 				textureFormat = this.context.DEPTH_STENCIL;
-			}
-			if (internalFormat === this.context.DEPTH_STENCIL) {
+			} else if (internalFormat === this.context.DEPTH_STENCIL) {
 				internalFormat = this.context.DEPTH24_STENCIL8
 			}
 			// SRGB and SRGB8_ALPHA8 not valid component for texture format


### PR DESCRIPTION
Fix for #24 
Follow #27 #26

Fix is needs because a Three still use a rgba8 as target of projection layer, and in polyfill this is down.

https://github.com/mrdoob/three.js/blob/master/src/renderers/webxr/WebXRManager.js#L307


Issues demo:

https://0zzmoo.csb.app/

https://codesandbox.io/s/happy-raman-0zzmoo?file=/src/index.ts

