### PR TITLE
Make sure views are initialized before allocating color textures

### DIFF
--- a/src/api/XRSessionWithLayer.ts
+++ b/src/api/XRSessionWithLayer.ts
@@ -87,7 +87,7 @@ export class XRSessionWithLayer {
 				}
 
 				// Layers MUST be cleared to (0, 0, 0, 0) at the beginning of the frame
-				if (this.isPolyfillActive) {
+				if (this.isPolyfillActive && this.initializedViews) {
 					if (!this.tempFramebuffer) {
 						this.tempFramebuffer = gl.createFramebuffer()
 					}


### PR DESCRIPTION
I've been trying to use the polyfill with smartphone AR.

On the first `session.requestAnimationFrame()`, I'm getting "We can't allocate color textures without views":

![Selection_432](https://user-images.githubusercontent.com/191561/201439255-59b9231b-9e7d-4239-9194-796420c6348d.png)

... which leads to this fatal error:

![Selection_433](https://user-images.githubusercontent.com/191561/201439277-a4b699c0-c0fa-4359-ac27-2bfb788eb143.png)

The problem is that with smartphone AR, `frame.getViewerPose(this.referenceSpace)` will return `null` for several frames (even up to a couple seconds) until it gains tracking.

Since we need to have the views in order to allocate the color textures, this PR makes sure we don't run that code until we have the views!

This fixes it in my testing :-)
